### PR TITLE
More efficiently handle large version lists

### DIFF
--- a/lib/advisory.js
+++ b/lib/advisory.js
@@ -65,7 +65,7 @@ class Advisory {
 
   // load up the data from a cache entry and a fetched packument
   load (cached, packument) {
-    // basic data integrity gutchecks
+    // basic data integrity gutcheck
     if (!cached || typeof cached !== 'object') {
       throw new TypeError('invalid cached data, expected object')
     }
@@ -148,7 +148,42 @@ class Advisory {
   }
 
   [_calculateRange] () {
-    const metavuln = this.vulnerableVersions.join(' || ').trim()
+    // calling semver.simplifyRange with a massive list of versions, and those
+    // versions all concatenated with `||` is a geometric CPU explosion!
+    // we can try to be a *little* smarter up front by doing x-y for all
+    // contiguous version sets in the list
+    const ranges = []
+    this.versions = semver.sort(this.versions)
+    this.vulnerableVersions = semver.sort(this.vulnerableVersions)
+    for (let v = 0, vulnVer = 0; v < this.versions.length; v++) {
+      // figure out the vulnerable subrange
+      const vr = [this.versions[v]]
+      while (v < this.versions.length) {
+        if (this.versions[v] !== this.vulnerableVersions[vulnVer]) {
+          // we don't test prerelease versions, so just skip past it
+          if (/-/.test(this.versions[v])) {
+            v++
+            continue
+          }
+          break
+        }
+        if (vr.length > 1)
+          vr[1] = this.versions[v]
+        else
+          vr.push(this.versions[v])
+        v++
+        vulnVer++
+      }
+      // it'll either be just the first version, which means no overlap,
+      // or the start and end versions, which might be the same version
+      if (vr.length > 1) {
+        const tail = this.versions[this.versions.length - 1]
+        ranges.push(vr[1] === tail ? `>=${vr[0]}`
+          : vr[0] === vr[1] ? vr[0]
+          : vr.join(' - '))
+      }
+    }
+    const metavuln = ranges.join(' || ').trim()
     this.range = !metavuln ? '<0.0.0-0'
       : semver.simplifyRange(this.versions, metavuln, semverOpt)
   }
@@ -271,25 +306,99 @@ class Advisory {
     }
 
     for (const list of versionSets) {
-      const headVuln = this.testVersion(list[0])
-      const tailVuln = this.testVersion(list[list.length - 1])
+      // it's common to have version lists like:
+      // 1.0.0
+      // 1.0.1-alpha.0
+      // 1.0.1-alpha.1
+      // ...
+      // 1.0.1-alpha.999
+      // 1.0.1
+      // 1.0.2-alpha.0
+      // ...
+      // 1.0.2-alpha.99
+      // 1.0.2
+      // with a huge number of prerelease versions that are not installable
+      // anyway.
+      // If mid has a prerelease tag, and list[0] does not, then walk it
+      // back until we hit a non-prerelease version
+      // If mid has a prerelease tag, and list[list.length-1] does not,
+      // then walk it forward until we hit a version without a prerelease tag
+      // Similarly, if the head/tail is a prerelease, but there is a non-pr
+      // version in the list, then start there instead.
+      let h = 0
+      const origHeadVuln = this.testVersion(list[h])
+      while (h < list.length && /-/.test(String(list[h])))
+        h++
+
+      // don't filter out the whole list!  they might all be pr's
+      if (h === list.length)
+        h = 0
+      else if (origHeadVuln) {
+        // if the original was vulnerable, assume so are all of these
+        for (let hh = 0; hh < h; hh++)
+          this[_markVulnerable](list[hh])
+      }
+
+      let t = list.length - 1
+      const origTailVuln = this.testVersion(list[t])
+      while (t > h && /-/.test(String(list[t])))
+        t--
+
+      // don't filter out the whole list!  might all be pr's
+      if (t === h)
+        t = list.length - 1
+      else if (origTailVuln) {
+        // if original tail was vulnerable, assume these are as well
+        for (let tt = list.length - 1; tt > t; tt--)
+          this[_markVulnerable](list[tt])
+      }
+
+      const headVuln = h === 0 ? origHeadVuln
+        : this.testVersion(list[h])
+
+      const tailVuln = t === list.length - 1 ? origTailVuln
+        : this.testVersion(list[t])
+
       // if head and tail both vulnerable, whole list is thrown out
       if (headVuln && tailVuln) {
-        for (const v of list.slice(1, -1)) {
-          this[_markVulnerable](v)
-        }
+        for (let v = h; v < t; v++)
+          this[_markVulnerable](list[v])
         continue
       }
 
       // if length is 2 or 1, then we marked them all already
-      if (list.length <= 2)
+      if (t < h + 2)
         continue
 
       const mid = Math.floor(list.length / 2)
-      // leave out the ends, since we tested those already
-      versionSets.add(list.slice(0, mid))
-      versionSets.add(list.slice(mid))
+      const pre = list.slice(0, mid)
+      const post = list.slice(mid)
+
+      // if the parent list wasn't prereleases, then drop pr tags
+      // from end of the pre list, and beginning of the post list,
+      // marking as vulnerable if the midpoint item we picked is.
+      if (!/-/.test(String(pre[0]))) {
+        const midVuln = this.testVersion(pre[pre.length - 1])
+        while (/-/.test(String(pre[pre.length-1]))) {
+          const v = pre.pop()
+          if (midVuln)
+            this[_markVulnerable](v)
+        }
+      }
+
+      if (!/-/.test(String(post[post.length-1]))) {
+        const midVuln = this.testVersion(post[0])
+        while (/-/.test(String(post[0]))) {
+          const v = post.shift()
+          if (midVuln)
+            this[_markVulnerable](v)
+        }
+      }
+
+      versionSets.add(pre)
+      versionSets.add(post)
     }
   }
 }
+
 module.exports = Advisory


### PR DESCRIPTION
More efficiently handle large version lists

- Skip most prerelease versions, if non-prerelease versions exist, since
  they are not going to be installed in normal operations anyway.
- Optimize the creation of simplified version ranges, so we don't have
  to walk every version in the set multiple times to simplify it.

This brings the case in npm/cli#2197 down from 10 minutes to about 10-20
seconds.  Comparing with the test case in the previous commit, we see a
roughly 60x performance improvement.

Fix: #1
Fix: https://github.com/npm/cli/issues/2197