### PR TITLE
fix NPE if dependencies fields are explicitly null in get-dep-spec

### DIFF
--- a/lib/get-dep-spec.js
+++ b/lib/get-dep-spec.js
@@ -3,13 +3,13 @@ module.exports = (mani, name) => {
   // where we aren't fetching a manifest from the registry
   // with multiple versions anyway.
   const {
-    dependencies: deps = {},
-    optionalDependencies: optDeps = {},
-    peerDependencies: peerDeps = {},
+    dependencies: deps,
+    optionalDependencies: optDeps,
+    peerDependencies: peerDeps,
   } = mani
 
-  return typeof deps[name] === 'string' ? deps[name]
-    : typeof optDeps[name] === 'string' ? optDeps[name]
-    : typeof peerDeps[name] === 'string' ? peerDeps[name]
+  return (deps && typeof deps[name] === 'string') ? deps[name]
+    : (optDeps && typeof optDeps[name] === 'string') ? optDeps[name]
+    : (peerDeps && typeof peerDeps[name] === 'string') ? peerDeps[name]
     : null
 }

--- a/test/get-dep-spec.js
+++ b/test/get-dep-spec.js
@@ -18,3 +18,8 @@ t.equal(getDepSpec({
 }, 'dep'), '1', 'prefer optional deps over peer')
 t.equal(getDepSpec({ devDependencies: { dep: '1' } }, 'dep'), null,
   'ignore dev')
+t.equal(getDepSpec({
+  dependencies: null,
+  optionalDependencies: null,
+  peerDependencies: null
+}, 'dep'), null, 'ignore null fields')


### PR DESCRIPTION
This fixes an NPE that happens when a project doesn't have a dependencies field in it's `package.json` on GitHub private packages repository.

In that case, the GitHub repository API returns `dependencies` explicitly to `null`, which means the default value assignment in `lib/get-dep-spec.js` doesn't kick in, and the process just crashes with an NPE.
This makes `npm audit` in npm 7 crash if you depend on a package hosted on GitHub private packages repository that has any version in it's history with no `dependencies` field.

This also cannot be fixed by pushing a new version to the repository as old versions will still return `dependencies: null`.

This is not a breaking change, and is just a safer behaviour than previously.

## Sample response from GitHub private repository

When calling: `https://npm.pkg.github.com/REDACTED_PACKAGE_NAME`
```json
{
  "name": "REDACTED_PACKAGE_NAME",
  "dist-tags": {
    "latest": "12.0.2"
  },
  "versions": {
    "10.14.6": {
      "dependencies": null,
```
