### PR TITLE
fix: handle null values for dependency objects

### DIFF
--- a/lib/get-dep-spec.js
+++ b/lib/get-dep-spec.js
@@ -8,8 +8,8 @@ module.exports = (mani, name) => {
     peerDependencies: peerDeps = {},
   } = mani
 
-  return typeof deps[name] === 'string' ? deps[name]
-    : typeof optDeps[name] === 'string' ? optDeps[name]
-    : typeof peerDeps[name] === 'string' ? peerDeps[name]
+  return deps && typeof deps[name] === 'string' ? deps[name]
+    : optDeps && typeof optDeps[name] === 'string' ? optDeps[name]
+    : peerDeps && typeof peerDeps[name] === 'string' ? peerDeps[name]
     : null
 }

--- a/test/get-dep-spec.js
+++ b/test/get-dep-spec.js
@@ -1,20 +1,44 @@
 const t = require('tap')
 const getDepSpec = require('../lib/get-dep-spec.js')
 
-t.equal(getDepSpec({ dependencies: { dep: '1' } }, 'dep'), '1')
-t.equal(getDepSpec({ optionalDependencies: { dep: '1' } }, 'dep'), '1')
-t.equal(getDepSpec({ peerDependencies: { dep: '1' } }, 'dep'), '1')
+t.equal(getDepSpec({
+  dependencies: { dep: '1' }
+}, 'dep'), '1')
+
+t.equal(getDepSpec({
+  optionalDependencies: { dep: '1' }
+}, 'dep'), '1')
+
+t.equal(getDepSpec({
+  dependencies: null,
+  optionalDependencies: { dep: '1' }
+}, 'dep'), '1', 'allows dependencies to be null')
+
+t.equal(getDepSpec({
+  peerDependencies: { dep: '1' }
+}, 'dep'), '1')
+
+t.equal(getDepSpec({
+  dependencies: null,
+  optioanlDependencies: null,
+  peerDependencies: { dep: '1' }
+}, 'dep'), '1', 'allows optionalDependencies to be null')
+
 t.equal(getDepSpec({
   dependencies: { dep: '1' },
   optionalDependencies: { dep: '2' },
 }, 'dep'), '1', 'prefer prod deps over optional')
+
 t.equal(getDepSpec({
   dependencies: { dep: '1' },
   peerDependencies: { dep: '2' },
 }, 'dep'), '1', 'prefer prod deps over peer')
+
 t.equal(getDepSpec({
   optionalDependencies: { dep: '1' },
   peerDependencies: { dep: '2' },
 }, 'dep'), '1', 'prefer optional deps over peer')
-t.equal(getDepSpec({ devDependencies: { dep: '1' } }, 'dep'), null,
-  'ignore dev')
+
+t.equal(getDepSpec({
+  devDependencies: { dep: '1' }
+}, 'dep'), null, 'ignore dev')


### PR DESCRIPTION
the current GitHub npm package registry returns packuments
where the various dependency objects are set to a null literal
which causes the destructuring defaults to not apply, so we
should guard against that for a bit of added safety here.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
