### PR TITLE
Check against undefined versions array from registry.

### DIFF
--- a/lib/advisory.js
+++ b/lib/advisory.js
@@ -99,7 +99,11 @@ class Advisory {
 
     this[_packument] = packument
 
-    const pakuVersions = Object.keys(packument.versions)
+    // Packages with similar names to unpublished registry packages will
+    // return registries without version array. While this is technically
+    // against spec, correct for it with a empty array.
+    const pakuVersions = packument.versions ? Object.keys(packument.versions) : []
+    
     const allVersions = new Set([...pakuVersions, ...this.versions])
     const versionsAdded = []
     const versionsRemoved = []
@@ -218,6 +222,10 @@ class Advisory {
     const sv = String(version)
     if (this.vulnerableVersions.includes(sv))
       return true
+
+    // If the listing contains no versions, then do not test.
+    if (!this[_packument].versions)
+      return false
 
     if (this.type === 'advisory') {
       // advisory, just test range


### PR DESCRIPTION
### What Changed
Checking to make sure that packument has a parameter called version. This has been updated during load and [_testVersion]

### Why Change This
A recent change at npmjs' registry now gives unpublished repositories a registry entry and returns 200. However these entries do not have any version arrays, which causes issues with the metavuln-calculator. If you were to use private packages through git, the package name gets matched up to unpublished repositories on npmjs' registry and breaks

It's possible that this is simply a bug on npmjs' side and this will be fixed in a future update, but this patch for now has allowed me to continue working as normal. I could also be missing something in my custom dependency that is confusing npm, so if there's any way to not need this patch, I'm all ears. I'll do my best to monitor this PR.


### Reproduction Steps 

- Create in npmjs with a unique name, `package-name` will be used in this reproduction steps
- Unpublish package-name
- Push up a valid package to a git source with the same name
- Try to install said package (this will also happen with package zips as well, anything with a matching name)

### Todo

- Needs unit tests written if to be merged in.
- Give a user a warning to know that their package may not have properly been screened
- Test dependencies of the non-registry package (maybe?)

### References
N/A
