### PR TITLE
fix: don't throw on invalid semver versions

### DIFF
--- a/lib/advisory.js
+++ b/lib/advisory.js
@@ -166,8 +166,8 @@ class Advisory {
     // we can try to be a *little* smarter up front by doing x-y for all
     // contiguous version sets in the list
     const ranges = []
-    this.versions = semver.sort(this.versions)
-    this.vulnerableVersions = semver.sort(this.vulnerableVersions)
+    this.versions = semver.sort(this.versions, semverOpt)
+    this.vulnerableVersions = semver.sort(this.vulnerableVersions, semverOpt)
     for (let v = 0, vulnVer = 0; v < this.versions.length; v++) {
       // figure out the vulnerable subrange
       const vr = [this.versions[v]]

--- a/test/advisory.js
+++ b/test/advisory.js
@@ -5,7 +5,7 @@ const Advisory = require('../lib/advisory.js')
 const advisories = require('./fixtures/advisories/index.js')
 const packuments = require('./fixtures/packuments/index.js')
 const semver = require('semver')
-const so = { includePrerelease: true }
+const so = { includePrerelease: true, loose: true }
 
 t.test('create vulns from advisory', t => {
   const v = new Advisory('semver', advisories.semver)
@@ -32,9 +32,9 @@ t.test('create vulns from advisory', t => {
     name: 'semver',
     title: 'Regular Expression Denial of Service',
     severity: 'moderate',
-    versions: semver.sort(Object.keys(packuments.semver.versions)),
+    versions: semver.sort(Object.keys(packuments.semver.versions), so),
     vulnerableVersions: semver.sort(Object.keys(packuments.semver.versions).filter(vulnerable =>
-      semver.satisfies(vulnerable, '<4.3.2', so))),
+      semver.satisfies(vulnerable, '<4.3.2', so)), so),
     url: 'https://npmjs.com/advisories/31',
     range: '<4.3.2',
     id: 'jETG9IyfV60PqVhvt3BAecPdQKL2CvXOXr1GeFeSsTkGn8YHi+dU93h8zcjK/xptcxeaYeUBBKmD83eafSecwA==',
@@ -55,9 +55,9 @@ t.test('create vulns from advisory', t => {
     name: 'semver',
     title: 'Regular Expression Denial of Service',
     severity: 'moderate',
-    versions: semver.sort(Object.keys(packuments.semver.versions)),
+    versions: semver.sort(Object.keys(packuments.semver.versions), so),
     vulnerableVersions: semver.sort(Object.keys(packuments.semver.versions).filter(vulnerable =>
-      semver.satisfies(vulnerable, '<4.3.2', so))),
+      semver.satisfies(vulnerable, '<4.3.2', so)), so),
     url: 'https://npmjs.com/advisories/31',
     range: '<4.3.2',
     id: 'jETG9IyfV60PqVhvt3BAecPdQKL2CvXOXr1GeFeSsTkGn8YHi+dU93h8zcjK/xptcxeaYeUBBKmD83eafSecwA==',
@@ -89,7 +89,7 @@ t.test('create vulns from advisory', t => {
     title: 'Depends on vulnerable versions of semver',
     url: null,
     severity: 'moderate',
-    versions: semver.sort(Object.keys(packuments.pacote.versions)),
+    versions: semver.sort(Object.keys(packuments.pacote.versions), so),
     vulnerableVersions: [],
     range: '<0.0.0-0',
     id: 'gJzFN5q57zHrhqiRn+lNQXirLlMUtC+8bFqEBGqE3XW/5VC880QTk2o/iRXUfJPT+jhc90QD+d9QIADI68nYlg==',
@@ -107,7 +107,7 @@ t.test('create vulns from advisory', t => {
     title: 'Depends on vulnerable versions of semver',
     url: null,
     severity: 'moderate',
-    versions: semver.sort(Object.keys(packuments.pacote.versions)),
+    versions: semver.sort(Object.keys(packuments.pacote.versions), so),
     vulnerableVersions: [],
     range: '<0.0.0-0',
     id: 'gJzFN5q57zHrhqiRn+lNQXirLlMUtC+8bFqEBGqE3XW/5VC880QTk2o/iRXUfJPT+jhc90QD+d9QIADI68nYlg==',
@@ -124,7 +124,7 @@ t.test('create vulns from advisory', t => {
     title: 'Depends on vulnerable versions of semver',
     url: null,
     severity: 'moderate',
-    versions: semver.sort(Object.keys(packuments.pacote.versions)),
+    versions: semver.sort(Object.keys(packuments.pacote.versions), so),
     vulnerableVersions: [],
     range: '<0.0.0-0',
     id: 'gJzFN5q57zHrhqiRn+lNQXirLlMUtC+8bFqEBGqE3XW/5VC880QTk2o/iRXUfJPT+jhc90QD+d9QIADI68nYlg==',
@@ -143,7 +143,7 @@ t.test('create vulns from advisory', t => {
     title: 'Depends on vulnerable versions of minimist',
     url: null,
     severity: 'low',
-    versions: semver.sort(Object.keys(packuments.mkdirp.versions)),
+    versions: semver.sort(Object.keys(packuments.mkdirp.versions), so),
     vulnerableVersions: ['0.4.1', '0.4.2', '0.5.0', '0.5.1'],
     range: '0.4.1 - 0.5.1',
     id: 'dOqvv9Jcyhu8PueSJZB+eZ0G/JI7mVomMmOBSku5SA7OScjvKmHq9jcLVFKmH1wsW2LcZATEOArlMxt/fa5LmA==',
@@ -169,7 +169,7 @@ t.test('create vulns from advisory', t => {
     title: 'Depends on vulnerable versions of minimist',
     url: null,
     severity: 'low',
-    versions: semver.sort(Object.keys(packuments.mkdirp.versions)),
+    versions: semver.sort(Object.keys(packuments.mkdirp.versions), so),
     vulnerableVersions: ['0.4.1', '0.4.2', '0.5.0', '0.5.1', '99.99.99'],
     range: '0.4.1 - 0.5.1 || >=99.99.99',
     id: 'dOqvv9Jcyhu8PueSJZB+eZ0G/JI7mVomMmOBSku5SA7OScjvKmHq9jcLVFKmH1wsW2LcZATEOArlMxt/fa5LmA==',
@@ -192,7 +192,7 @@ t.test('create vulns from advisory', t => {
     title: 'Depends on vulnerable versions of minimist',
     url: null,
     severity: 'low',
-    versions: semver.sort(Object.keys(packuments.mkdirp.versions)),
+    versions: semver.sort(Object.keys(packuments.mkdirp.versions), so),
     vulnerableVersions: ['0.4.1', '0.4.2', '0.5.0-bundler', '0.5.0', '0.5.1', '99.99.99'],
     range: '0.4.1 - 0.5.1 || >=99.99.99',
     id: 'dOqvv9Jcyhu8PueSJZB+eZ0G/JI7mVomMmOBSku5SA7OScjvKmHq9jcLVFKmH1wsW2LcZATEOArlMxt/fa5LmA==',
@@ -220,7 +220,7 @@ t.test('create vulns from advisory', t => {
     title: 'Depends on vulnerable versions of minimist',
     url: null,
     severity: 'low',
-    versions: semver.sort(Object.keys(packuments.mkdirp.versions)),
+    versions: semver.sort(Object.keys(packuments.mkdirp.versions), so),
     vulnerableVersions: ['0.4.1', '0.4.2', '0.5.0', '0.5.1'],
     range: '0.4.1 - 0.5.1',
     id: 'dOqvv9Jcyhu8PueSJZB+eZ0G/JI7mVomMmOBSku5SA7OScjvKmHq9jcLVFKmH1wsW2LcZATEOArlMxt/fa5LmA==',

--- a/test/fixtures/packuments/pacote.json
+++ b/test/fixtures/packuments/pacote.json
@@ -5,7 +5,7 @@
     "v9-legacy": "9.5.12"
   },
   "versions": {
-    "0.0.0": {
+    "0.0.0pre92": {
       "name": "pacote",
       "version": "0.0.0",
       "dist": {


### PR DESCRIPTION
This PR is a first step to fix https://github.com/npm/cli/issues/5017

Since npm 8.x, `npm audit` crashes on package [`yui`](https://www.npmjs.com/package/yui) with the following error:
```
npm ERR! Invalid Version: 3.5.0pr2
```

After some digging, it turns out that some calls to `semver.sort()` miss the `semverOpt` (espacially the `loose: true` option) parameter in `@npmcli/metavuln-calculator/lib/advisory.js`.

I am not familiar neither with this package nor with its testing tools, so I was not able to write a test for this.