### PR TITLE
Add new test for following update to lib/advisory.js

### DIFF
--- a/lib/advisory.js
+++ b/lib/advisory.js
@@ -106,7 +106,7 @@ class Advisory {
 
     this[_packument] = packument
 
-    const pakuVersions = Object.keys(packument.versions)
+    const pakuVersions = packument.versions ? Object.keys(packument.versions) : []
     const allVersions = new Set([...pakuVersions, ...this.versions])
     const versionsAdded = []
     const versionsRemoved = []
@@ -242,11 +242,12 @@ class Advisory {
     // check the dependency of this version on the vulnerable dep
     // if we got a version that's not in the packument, fall back on
     // the spec provided, if possible.
-    const mani = this[_packument].versions[version] || {
-      dependencies: {
-        [this.dependency]: spec,
-      },
-    }
+    const mani = this[_packument].versions &&
+      this[_packument].versions[version] ? this[_packument].versions[version] : {
+        dependencies: {
+          [this.dependency]: spec,
+        },
+      }
 
     if (!spec) {
       spec = getDepSpec(mani, this.dependency)


### PR DESCRIPTION
This PR intends to address [issue #80](https://github.com/npm/metavuln-calculator/issues/80)

- The changes in this PR were inspired from: https://github.com/npm/metavuln-calculator/pull/81
- I will be quick to approve any PRs against my branch (to become part of this PR as needed.)

To recreate the issue:
```bash
npm i -g npm-remote-ls;
npx npm-remote-ls metavuln-calculator;
```

```results
Cannot convert undefined or null to object
```

I believe this indicates an issue: `npm i `

```results
npm ERR! code ENOVERSIONS
npm ERR! No versions available for metavuln-calculator
```

```npm-debug-log
40 silly fetch manifest metavuln-calculator@*
41 http fetch GET 200 https://registry.npmjs.org/metavuln-calculator 22ms (cache hit)
42 silly placeDep ROOT metavuln-calculator@ OK for: temp@1.0.0 want: *
43 timing idealTree:#root Completed in 27ms
44 timing idealTree:node_modules/metavuln-calculator Completed in 0ms
45 timing idealTree:buildDeps Completed in 28ms
46 timing idealTree:fixDepFlags Completed in 0ms
47 timing idealTree Completed in 43ms
48 timing command:i Completed in 47ms
49 verbose type range
50 verbose stack metavuln-calculator: No versions available for metavuln-calculator
50 verbose stack     at pickManifest (/home/michael/.nvm/versions/node/v16.19.0/lib/node_modules/npm/node_modules/npm-pick-manifest/lib/index.js:140:25)
50 verbose stack     at module.exports (/home/michael/.nvm/versions/node/v16.19.0/lib/node_modules/npm/node_modules/npm-pick-manifest/lib/index.js:187:16)
50 verbose stack     at RegistryFetcher.manifest (/home/michael/.nvm/versions/node/v16.19.0/lib/node_modules/npm/node_modules/pacote/lib/registry.js:125:22)
50 verbose stack     at async Arborist.[nodeFromEdge] (/home/michael/.nvm/versions/node/v16.19.0/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/build-ideal-tree.js:1061:19)
50 verbose stack     at async Arborist.[buildDepStep] (/home/michael/.nvm/versions/node/v16.19.0/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/build-ideal-tree.js:930:11)
50 verbose stack     at async Arborist.buildIdealTree (/home/michael/.nvm/versions/node/v16.19.0/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/build-ideal-tree.js:211:7)
50 verbose stack     at async Promise.all (index 1)
50 verbose stack     at async Arborist.reify (/home/michael/.nvm/versions/node/v16.19.0/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/reify.js:154:5)
50 verbose stack     at async Install.exec (/home/michael/.nvm/versions/node/v16.19.0/lib/node_modules/npm/lib/commands/install.js:145:5)
50 verbose stack     at async module.exports (/home/michael/.nvm/versions/node/v16.19.0/lib/node_modules/npm/lib/cli.js:78:5)
51 verbose cwd /home/michael/src/Asurion/HORIZON_REPOS/temp
52 verbose Linux 5.15.90.1-microsoft-standard-WSL2
53 verbose node v16.19.0
54 verbose npm  v8.19.3
55 error code ENOVERSIONS
56 error No versions available for metavuln-calculator
57 verbose exit 1
58 timing npm Completed in 108ms
59 verbose unfinished npm timer reify 1680475765436
60 verbose unfinished npm timer reify:loadTrees 1680475765438
61 verbose code 1
62 error A complete log of this run can be found in:
62 error     /home/michael/.npm/_logs/2023-04-02T22_49_25_377Z-debug-0.log
```

To recreate the issue, run `npm -g npx npm-remote-ls metavuln-calculator

Test results:
 PASS ​ test/get-dep-spec.js 9 OK 80.623ms
​ PASS ​ test/hash.js 5 OK 4.714ms
​ PASS ​ test/index.js 12 OK 184.228ms
​ PASS ​ test/advisory.js 29 OK 2s
                         
  🌈 SUMMARY RESULTS 🌈  
                         
Suites:   ​4 passed​, ​4 of 4 completed​
Asserts:  ​​​55 passed​, ​of 55​
​Time:​   ​3s​
ERROR: Coverage for branches (99.38%) does not meet global threshold (100%)
-----------------|---------|----------|---------|---------|-------------------
File             | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------------|---------|----------|---------|---------|-------------------
All files        |     100 |    99.38 |     100 |     100 |                   
 advisory.js     |     100 |    99.27 |     100 |     100 | 109               
 get-dep-spec.js |     100 |      100 |     100 |     100 |                   
 hash.js         |     100 |      100 |     100 |     100 |                   
 index.js        |     100 |      100 |     100 |     100 |                   
-----------------|---------|----------|---------|---------|-------------------