### PR TITLE
Bugfix/support packument without versions

### DIFF
--- a/lib/advisory.js
+++ b/lib/advisory.js
@@ -106,7 +106,7 @@ class Advisory {
 
     this[_packument] = packument
 
-    const pakuVersions = Object.keys(packument.versions)
+    const pakuVersions = Object.keys(packument.versions || {})
     const allVersions = new Set([...pakuVersions, ...this.versions])
     const versionsAdded = []
     const versionsRemoved = []
@@ -242,7 +242,7 @@ class Advisory {
     // check the dependency of this version on the vulnerable dep
     // if we got a version that's not in the packument, fall back on
     // the spec provided, if possible.
-    const mani = this[_packument].versions[version] || {
+    const mani = this[_packument]?.versions?.[version] || {
       dependencies: {
         [this.dependency]: spec,
       },

--- a/test/advisory.js
+++ b/test/advisory.js
@@ -273,6 +273,28 @@ t.test('load with empty packument', t => {
   t.end()
 })
 
+t.test('load with no package version in packument', t => {
+  const v = new Advisory('semver', advisories.semver)
+  v.load({}, { name: 'semver' })
+  t.match(v, {
+    constructor: Advisory,
+    source: 31,
+    name: 'semver',
+    dependency: 'semver',
+    title: 'Regular Expression Denial of Service',
+    url: 'https://npmjs.com/advisories/31',
+    severity: 'moderate',
+    versions: [],
+    vulnerableVersions: [],
+    range: '<4.3.2',
+    id: 'jETG9IyfV60PqVhvt3BAecPdQKL2CvXOXr1GeFeSsTkGn8YHi+dU93h8zcjK/xptcxeaYeUBBKmD83eafSecwA==',
+  })
+
+  t.ok(v.testVersion('4.3.1'), 'version covered by range is vulnerable')
+  t.match(v, { vulnerableVersions: ['4.3.1'], versions: [] }, 'added to set')
+  t.end()
+})
+
 t.test('a package with a lot of prerelease versions', t => {
   const a = advisories['graphql-codegen-plugin-helpers']
   const v = new Advisory('@graphql-codegen/plugin-helpers', a)


### PR DESCRIPTION
This PR fixes [issue 84](https://github.com/npm/metavuln-calculator/issues/84) that is caused when npm tries to audit packages that are installed as github dependencies. These packages don't have any versions on loaded packument and this is causing breaking error because Object.keys doesn't work on null/undefined and also later codebase tries to access versions property of undefined versions field.

## References
  Related to #84
  Fixes #84
  Closes #84
