### PR TITLE
fix: add error codes to advisory load errors

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -85,7 +85,7 @@ jobs:
             os: macos-latest
             shell: bash
           - name: macOS
-            os: macos-13
+            os: macos-15-intel
             shell: bash
           - name: Windows
             os: windows-latest
@@ -100,21 +100,21 @@ jobs:
           - 22.9.0
           - 22.x
         exclude:
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 16.14.0
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 16.x
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 18.0.0
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 18.x
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 20.17.0
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 20.x
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 22.9.0
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 22.x
     runs-on: ${{ matrix.platform.os }}
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
             os: macos-latest
             shell: bash
           - name: macOS
-            os: macos-13
+            os: macos-15-intel
             shell: bash
           - name: Windows
             os: windows-latest
@@ -76,21 +76,21 @@ jobs:
           - 22.9.0
           - 22.x
         exclude:
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 16.14.0
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 16.x
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 18.0.0
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 18.x
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 20.17.0
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 20.x
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 22.9.0
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 22.x
     runs-on: ${{ matrix.platform.os }}
     defaults:

--- a/lib/advisory.js
+++ b/lib/advisory.js
@@ -83,12 +83,14 @@ class Advisory {
 
     if (cached.id && cached.id !== this.id) {
       throw Object.assign(new Error('loading from incorrect cache entry'), {
+        code: 'ECACHEMISMATCH',
         expected: this.id,
         actual: cached.id,
       })
     }
     if (packument.name !== this.name) {
       throw Object.assign(new Error('loading from incorrect packument'), {
+        code: 'EPACKUMENTMISMATCH',
         expected: this.name,
         actual: packument.name,
       })

--- a/test/advisory.js
+++ b/test/advisory.js
@@ -235,11 +235,13 @@ t.test('create vulns from advisory', t => {
     message: 'invalid packument data, expected object',
   })
   t.throws(() => mkdirpVuln.load({ id: 'wrong' }, {}), {
+    code: 'ECACHEMISMATCH',
     message: 'loading from incorrect cache entry',
     expected: mkdirpVuln.id,
     actual: 'wrong',
   })
   t.throws(() => mkdirpVuln.load({}, packuments.minimist), {
+    code: 'EPACKUMENTMISMATCH',
     message: 'loading from incorrect packument',
     expected: 'mkdirp',
     actual: 'minimist',


### PR DESCRIPTION
fix: add error codes to advisory load errors
 
 Errors thrown in advisory.load() for cache and packument mismatches now include a `code` property (`ECACHEMISMATCH` and `EPACKUMENTMISMATCH`). This allows downstream consumers like the npm CLI to provide more actionable error messages by keying off the code and displaying the `expected` and `actual` fields.
 
 related: https://github.com/npm/cli/issues/8133